### PR TITLE
Adds weekly benchmarks, tencent test run

### DIFF
--- a/.github/cloudRun/cloud-tests-local-trigger.sh
+++ b/.github/cloudRun/cloud-tests-local-trigger.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -eo pipefail
+
 cd "$(dirname "$0")" || exit 1
 
 GITHUB_RUN_ID=$1
@@ -13,24 +15,24 @@ echo "Prover IP: $PROVER_IP"
 rm ~/.ssh/known_hosts*
 
 prepare_env() {
-  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- <../weeklyBenchScripts/00_installGo.sh
-  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- <../weeklyBenchScripts/00_installRust.sh
-  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- <../weeklyBenchScripts/01_installDeps.sh
-  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- <../weeklyBenchScripts/02_setup.sh
+  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@"$PROVER_IP" "bash -s" -- <../weeklyBenchScripts/00_installGo.sh
+  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@"$PROVER_IP" "bash -s" -- <../weeklyBenchScripts/00_installRust.sh
+  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@"$PROVER_IP" "bash -s" -- <../weeklyBenchScripts/01_installDeps.sh
+  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@"$PROVER_IP" "bash -s" -- <../weeklyBenchScripts/02_setup.sh
 }
 
 prepare_repo() {
-  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- "$GITHUB_RUN_ID" <../weeklyBenchScripts/03_prepareProver.sh
-  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- "$GITHUB_RUN_ID" "$BRANCH_NAME" <../weeklyBenchScripts/04_clone.sh
-  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- "$GITHUB_RUN_ID" <../weeklyBenchScripts/05_build.sh
+  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@"$PROVER_IP" "bash -s" -- "$GITHUB_RUN_ID" <../weeklyBenchScripts/03_prepareProver.sh
+  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@"$PROVER_IP" "bash -s" -- "$GITHUB_RUN_ID" "$BRANCH_NAME" <../weeklyBenchScripts/04_clone.sh
+  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@"$PROVER_IP" "bash -s" -- "$GITHUB_RUN_ID" <../weeklyBenchScripts/05_build.sh
 
 }
 
 prepare_env
 prepare_repo
 
-ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- "$GITHUB_RUN_ID" <run.sh
-scp -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP:"$HOME"/CI_Prover_Benches/"$GITHUB_RUN_ID"/run_result ../../../
+ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@"$PROVER_IP" "bash -s" -- "$GITHUB_RUN_ID" <run.sh
+scp -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@"$PROVER_IP":"$HOME"/CI_Prover_Benches/"$GITHUB_RUN_ID"/run_result ../../../
 RESULT=$(cat ../../../run_result)
 echo "exiting cloud-tests-local-trigger with RESULT $RESULT"
-exit $RESULT
+exit "$RESULT"

--- a/.github/cloudRun/cloud-tests-local-trigger.sh
+++ b/.github/cloudRun/cloud-tests-local-trigger.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+cd "$(dirname "$0")" || exit 1
+
+GITHUB_RUN_ID=$1
+BRANCH_NAME=$2
+
+PROVER_INSTANCE=$(cat "$HOME/CI_Github_Trigger/$GITHUB_RUN_ID/prover_instance")
+echo "Prover instance at trigger: $PROVER_INSTANCE"
+
+export PROVER_IP=$(tccli cvm DescribeInstances --InstanceIds "[\"$PROVER_INSTANCE\"]" | grep -A 1 PublicIpAddress | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')
+echo "Prover IP: $PROVER_IP"
+
+rm ~/.ssh/known_hosts*
+
+prepare_env() {
+  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- <../weeklyBenchScripts/00_installGo.sh
+  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- <../weeklyBenchScripts/00_installRust.sh
+  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- <../weeklyBenchScripts/01_installDeps.sh
+  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- <../weeklyBenchScripts/02_setup.sh
+}
+
+prepare_repo() {
+  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- "$GITHUB_RUN_ID" <../weeklyBenchScripts/03_prepareProver.sh
+  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- "$GITHUB_RUN_ID" "$BRANCH_NAME" <../weeklyBenchScripts/04_clone.sh
+  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- "$GITHUB_RUN_ID" <../weeklyBenchScripts/05_build.sh
+
+}
+
+prepare_env
+prepare_repo
+
+ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- "$GITHUB_RUN_ID" <run.sh
+scp -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP:"$HOME"/CI_Prover_Benches/"$GITHUB_RUN_ID"/run_result ../../../
+RESULT=$(cat ../../../run_result)
+echo "exiting cloud-tests-local-trigger with RESULT $RESULT"
+exit $RESULT

--- a/.github/cloudRun/cloud-tests-trigger.sh
+++ b/.github/cloudRun/cloud-tests-trigger.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -eo pipefail
+
 GITHUB_RUN_ID=$1
 BRANCH_NAME=$2
 
@@ -17,19 +19,19 @@ ensure_git_installed
 clone_zkevm-circuits() {
   git clone -q https://github.com/taikoxyz/zkevm-circuits.git
   cd zkevm-circuits || exit 1
-  git checkout $BRANCH_NAME
+  git checkout "$BRANCH_NAME"
   echo "Cloned zkevm-circuits"
 }
 
 directory_name="$HOME/CI_Github_Trigger/$GITHUB_RUN_ID"
-cd $directory_name || exit 1
+cd "$directory_name" || exit 1
 
 
 clone_zkevm-circuits
 
 cd .github/cloudRun || exit 1
 chmod u+x cloud-tests-local-trigger.sh
-./cloud-tests-local-trigger.sh $GITHUB_RUN_ID $BRANCH_NAME
+./cloud-tests-local-trigger.sh "$GITHUB_RUN_ID" "$BRANCH_NAME"
 RESULT=$?
 echo "exiting cloud-tests-trigger with result $RESULT"
 exit $RESULT

--- a/.github/cloudRun/cloud-tests-trigger.sh
+++ b/.github/cloudRun/cloud-tests-trigger.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+GITHUB_RUN_ID=$1
+BRANCH_NAME=$2
+
+ensure_git_installed() {
+  if ! command -v git &>/dev/null; then
+    echo "Git is not installed. Installing..."
+    sudo apt update
+    sudo apt install -y git
+  else
+    echo "Git is already installed."
+  fi
+}
+
+ensure_git_installed
+
+clone_zkevm-circuits() {
+  git clone -q https://github.com/taikoxyz/zkevm-circuits.git
+  cd zkevm-circuits || exit 1
+  git checkout $BRANCH_NAME
+  echo "Cloned zkevm-circuits"
+}
+
+directory_name="$HOME/CI_Github_Trigger/$GITHUB_RUN_ID"
+cd $directory_name || exit 1
+
+
+clone_zkevm-circuits
+
+cd .github/cloudRun || exit 1
+chmod u+x cloud-tests-local-trigger.sh
+./cloud-tests-local-trigger.sh $GITHUB_RUN_ID $BRANCH_NAME
+RESULT=$?
+echo "exiting cloud-tests-trigger with result $RESULT"
+exit $RESULT

--- a/.github/cloudRun/github-action-trigger.sh
+++ b/.github/cloudRun/github-action-trigger.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+sshpass -p $BENCH_RESULTS_PASS ssh -o StrictHostKeyChecking=no ubuntu@43.130.90.57 "bash -s" -- "$GITHUB_RUN_ID" "$BRANCH_NAME" <cloud-tests-trigger.sh
+RESULT=$?
+echo "exiting github-action-trigger with RESULT=$RESULT"
+exit $RESULT

--- a/.github/cloudRun/github-action-trigger.sh
+++ b/.github/cloudRun/github-action-trigger.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+set -eo pipefail
 
-sshpass -p $BENCH_RESULTS_PASS ssh -o StrictHostKeyChecking=no ubuntu@43.130.90.57 "bash -s" -- "$GITHUB_RUN_ID" "$BRANCH_NAME" <cloud-tests-trigger.sh
+sshpass -p "$BENCH_RESULTS_PASS" ssh -o StrictHostKeyChecking=no ubuntu@43.130.90.57 "bash -s" -- "$GITHUB_RUN_ID" "$BRANCH_NAME" <cloud-tests-trigger.sh
 RESULT=$?
 echo "exiting github-action-trigger with RESULT=$RESULT"
 exit $RESULT

--- a/.github/cloudRun/run.sh
+++ b/.github/cloudRun/run.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -eo pipefail
+
 GITHUB_RUN_ID=$1
 export GOROOT="/usr/local/go"
 export GOPATH="$HOME/go"
@@ -9,7 +11,7 @@ current_dir="$HOME"/CI_Prover_Benches/"$GITHUB_RUN_ID"
 
 target_dir="$current_dir/zkevm-circuits"
 
-cd $target_dir || exit 1
+cd "$target_dir" || exit 1
 
 # ENTER YOUR TEST COMMAND BELOW
 make test-all

--- a/.github/cloudRun/run.sh
+++ b/.github/cloudRun/run.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+GITHUB_RUN_ID=$1
+export GOROOT="/usr/local/go"
+export GOPATH="$HOME/go"
+export PATH="$GOROOT/bin:$GOPATH/bin:$PATH:$HOME/.cargo/bin/"
+
+# Get the latest temp directory in the home directory
+current_dir="$HOME"/CI_Prover_Benches/"$GITHUB_RUN_ID"
+
+target_dir="$current_dir/zkevm-circuits"
+
+cd $target_dir || exit 1
+
+# ENTER YOUR TEST COMMAND BELOW
+make test-all
+# ENTER YOUR TEST COMMAND ABOVE
+
+RESULT=$?
+echo $RESULT > ../run_result
+echo "exiting run.sh with RESULT $RESULT"

--- a/.github/weeklyBenchScripts/00_installGo.sh
+++ b/.github/weeklyBenchScripts/00_installGo.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 
 # Check if Go is already installed
 if command -v go &>/dev/null; then

--- a/.github/weeklyBenchScripts/00_installGo.sh
+++ b/.github/weeklyBenchScripts/00_installGo.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Check if Go is already installed
+if command -v go &>/dev/null; then
+    echo "Go is already installed."
+else
+    # Set the Go version to be installed (latest as of current date)
+    GO_VERSION="1.19.1"
+
+    # Determine the architecture
+    ARCH="amd64"
+
+    # Download and extract the Go archive
+    wget -q "https://golang.org/dl/go$GO_VERSION.linux-$ARCH.tar.gz"
+    sudo tar -C /usr/local -xzf "go$GO_VERSION.linux-$ARCH.tar.gz"
+
+    # Set Go environment variables
+    export GOROOT="/usr/local/go"
+    export GOPATH="$HOME/go"
+    export PATH="$GOROOT/bin:$GOPATH/bin:$PATH"
+
+    # Append Go environment variables to the shell profile
+    echo 'export GOROOT="/usr/local/go"' >> "$HOME/.bashrc"
+    echo 'export GOPATH="$HOME/go"' >> "$HOME/.bashrc"
+    echo 'export PATH="$GOROOT/bin:$GOPATH/bin:$PATH"' >> "$HOME/.bashrc"
+
+    # Refresh the shell session to make Go available
+    source "$HOME/.bashrc"
+
+    # Cleanup the downloaded archive
+    rm "go$GO_VERSION.linux-$ARCH.tar.gz"
+
+    echo "Go $GO_VERSION has been installed successfully."
+fi
+
+# Display the installed Go version
+go version
+

--- a/.github/weeklyBenchScripts/00_installRust.sh
+++ b/.github/weeklyBenchScripts/00_installRust.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
+set -eo pipefail
 
 # Check if rustup is already installed
 if ! command -v rustup &>/dev/null; then
     echo "Installing rustup..."
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-    source $HOME/.cargo/env
+    source "$HOME"/.cargo/env
 else
     echo "rustup is already installed. Checking for updates..."
     rustup update

--- a/.github/weeklyBenchScripts/00_installRust.sh
+++ b/.github/weeklyBenchScripts/00_installRust.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Check if rustup is already installed
+if ! command -v rustup &>/dev/null; then
+    echo "Installing rustup..."
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    source $HOME/.cargo/env
+else
+    echo "rustup is already installed. Checking for updates..."
+    rustup update
+fi
+
+# Install the latest version of Rust
+echo "Installing the latest version of Rust..."
+rustup install stable
+
+# Set the latest version as the default
+rustup default stable
+
+# Print the installed Rust version
+echo "Rust has been installed successfully. Current version:"
+rustc --version
+cargo --version
+

--- a/.github/weeklyBenchScripts/01_installDeps.sh
+++ b/.github/weeklyBenchScripts/01_installDeps.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+sudo apt update
+
+# Check if Git is already installed
+if command -v git &>/dev/null; then
+    echo "Git is already installed."
+else
+    # Detect the Linux distribution and install Git
+    if [[ -f /etc/os-release ]]; then
+        source /etc/os-release
+        if [[ $ID == "ubuntu" || $ID == "debian" ]]; then
+            sudo apt install -y git
+        elif [[ $ID == "centos" || $ID == "rhel" ]]; then
+            sudo yum install -y git
+        elif [[ $ID == "fedora" ]]; then
+            sudo dnf install -y git
+        else
+            echo "Unsupported Linux distribution. Please install Git manually."
+            exit 1
+        fi
+    else
+        echo "Cannot determine the Linux distribution. Please install Git manually."
+        exit 1
+    fi
+
+    # Verify Git installation
+    if command -v git &>/dev/null; then
+        echo "Git has been installed successfully."
+    else
+        echo "Failed to install Git. Please install it manually."
+    fi
+fi
+
+# Check if the C compiler is installed
+if ! command -v cc &>/dev/null; then
+    # Detect the Linux distribution and install the C compiler
+    if [[ -f /etc/os-release ]]; then
+        source /etc/os-release
+        if [[ $ID == "ubuntu" || $ID == "debian" ]]; then
+            sudo apt install -y build-essential
+        elif [[ $ID == "centos" || $ID == "rhel" ]]; then
+            sudo yum groupinstall -y "Development Tools"
+        elif [[ $ID == "fedora" ]]; then
+            sudo dnf groupinstall -y "Development Tools"
+        else
+            echo "Unsupported Linux distribution. Please install the C compiler manually."
+            exit 1
+        fi
+    else
+        echo "Cannot determine the Linux distribution. Please install the C compiler manually."
+        exit 1
+    fi
+
+    # Verify C compiler installation
+    if command -v cc &>/dev/null; then
+        echo "The C compiler has been installed successfully."
+    else
+        echo "Failed to install the C compiler. Please install it manually."
+    fi
+fi
+
+sudo apt install -y pkg-config fontconfig libfontconfig-dev

--- a/.github/weeklyBenchScripts/01_installDeps.sh
+++ b/.github/weeklyBenchScripts/01_installDeps.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -eo pipefail
+
 sudo apt update
 
 # Check if Git is already installed

--- a/.github/weeklyBenchScripts/02_setup.sh
+++ b/.github/weeklyBenchScripts/02_setup.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Function to check if sysstat is installed
+check_sysstat_installed() {
+  if command -v sar &>/dev/null; then
+    echo "sysstat is already installed."
+    return 0
+  else
+    echo "sysstat is not installed."
+    return 1
+  fi
+}
+
+# Function to install sysstat
+install_sysstat() {
+  if [[ -f /etc/os-release ]]; then
+    source /etc/os-release
+    if [[ $ID == "ubuntu" || $ID == "debian" ]]; then
+      sudo apt update
+      sudo apt install -y sysstat
+    elif [[ $ID == "centos" || $ID == "rhel" ]]; then
+      sudo yum install -y sysstat
+    else
+      echo "Unsupported operating system. Please install sysstat manually."
+      exit 1
+    fi
+  else
+    echo "Cannot determine the operating system. Please install sysstat manually."
+    exit 1
+  fi
+}
+
+# Function to enable sysstat service
+enable_sysstat_service() {
+  sudo systemctl enable sysstat
+  sudo systemctl start sysstat
+  echo "sysstat service has been enabled and started."
+}
+
+# Main script
+sudo timedatectl set-timezone UTC
+check_sysstat_installed
+if [[ $? -ne 0 ]]; then
+  install_sysstat
+fi
+
+enable_sysstat_service
+

--- a/.github/weeklyBenchScripts/02_setup.sh
+++ b/.github/weeklyBenchScripts/02_setup.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 
 # Function to check if sysstat is installed
 check_sysstat_installed() {

--- a/.github/weeklyBenchScripts/03_prepareProver.sh
+++ b/.github/weeklyBenchScripts/03_prepareProver.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+GITHUB_RUN_ID=$1
+
+# Set up the directory name with the timestamp
+directory_name="CI_Prover_Benches/$GITHUB_RUN_ID"
+
+# Set up the full path for the directory in the home directory
+directory_path="$HOME/$directory_name"
+
+# Create the directory
+if [ ! -d "$directory_path" ]; then
+  mkdir -p "$directory_path"
+  echo "Directory '$directory_name' with GITHUB_RUN_ID '$GITHUB_RUN_ID' has been created in the home directory."
+fi
+

--- a/.github/weeklyBenchScripts/03_prepareProver.sh
+++ b/.github/weeklyBenchScripts/03_prepareProver.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 
 GITHUB_RUN_ID=$1
 

--- a/.github/weeklyBenchScripts/04_clone.sh
+++ b/.github/weeklyBenchScripts/04_clone.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 
 GITHUB_RUN_ID=$1
 

--- a/.github/weeklyBenchScripts/04_clone.sh
+++ b/.github/weeklyBenchScripts/04_clone.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+GITHUB_RUN_ID=$1
+
+# Get the latest temp directory in the home directory
+current_dir="$HOME"/CI_Prover_Benches/"$GITHUB_RUN_ID"
+target_dir="$current_dir"/zkevm-circuits
+
+if [ ! -d "$target_dir" ]; then
+  # Clone the repository into the latest temp directory
+  echo "Cloning the repository into the latest temp directory: $current_dir"
+  git clone -q https://github.com/taikoxyz/zkevm-circuits.git "$current_dir/zkevm-circuits"
+
+  if [ -n "$BRANCH_NAME" ]; then
+    old_dir=$(pwd)
+    cd "$current_dir/zkevm-circuits" || exit 1
+    git checkout "$BRANCH_NAME"
+    cd "$old_dir" || exit 1
+  fi
+  # Print a message to indicate successful cloning
+  echo "Repository cloned successfully into: $current_dir/zkevm-circuits"
+fi

--- a/.github/weeklyBenchScripts/05_build.sh
+++ b/.github/weeklyBenchScripts/05_build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+GITHUB_RUN_ID=$1
+
+export GOROOT="/usr/local/go"
+export GOPATH="$HOME/go"
+export PATH="$GOROOT/bin:$GOPATH/bin:$PATH"
+
+# Get the latest temp directory in the home directory
+current_dir="$HOME"/CI_Prover_Benches/"$GITHUB_RUN_ID"
+
+if [ -z "$current_dir" ]; then
+    echo "No temp directory found starting with 'CI_Prover_Benches__' in the home directory."
+    exit 1
+fi
+
+echo "Building zkevm-circuits inside: $current_dir"
+cd "$current_dir/zkevm-circuits" || exit 1
+~/.cargo/bin/cargo build -q
+

--- a/.github/weeklyBenchScripts/05_build.sh
+++ b/.github/weeklyBenchScripts/05_build.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -eo pipefail
+
 GITHUB_RUN_ID=$1
 
 export GOROOT="/usr/local/go"

--- a/.github/weeklyBenchScripts/06_rsSysstat.sh
+++ b/.github/weeklyBenchScripts/06_rsSysstat.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#set -e
+#set -x
+echo "Killing sadc"
+sudo pkill sadc
+echo "Cleaning /var/log/sysstat"
+sudo rm -rf /var/log/sysstat/*
+echo "Running sadc"
+nohup sudo /usr/lib/sysstat/sadc -S ALL 10 604800 /var/log/sysstat/ &
+disown
+

--- a/.github/weeklyBenchScripts/06_rsSysstat.sh
+++ b/.github/weeklyBenchScripts/06_rsSysstat.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-#set -e
-#set -x
+set -eo pipefail
+
 echo "Killing sadc"
 sudo pkill sadc
 echo "Cleaning /var/log/sysstat"

--- a/.github/weeklyBenchScripts/07_execBench.sh
+++ b/.github/weeklyBenchScripts/07_execBench.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-set -e
-#set -x
+set -eo pipefail
+
 GITHUB_RUN_ID=$3
 export GOROOT="/usr/local/go"
 export GOPATH="$HOME/go"
@@ -11,7 +11,7 @@ current_dir="$HOME"/CI_Prover_Benches/"$GITHUB_RUN_ID"
 
 target_dir="$current_dir/zkevm-circuits"
 k=$1
-circuit=$(echo $2 | awk '{ print $1 }' | tr '[:upper:]' '[:lower:]')
+circuit=$(echo "$2" | awk '{ print $1 }' | tr '[:upper:]' '[:lower:]')
 printf -v _date '%(%Y-%m-%d_%H:%M:%S)T' -1
 
 case $circuit in
@@ -52,17 +52,14 @@ case $circuit in
         ;;
 esac
 
-cd $target_dir;
+cd "$target_dir";
 
 mkdir ../results
-logfile=$_date--${circuit}_bench-$k.proverlog
+logfile="$_date"--"${circuit}"_bench-"$k".proverlog
 
 current_time=$(date +'%H:%M:%S')
 echo "Current time: $current_time"
-echo $current_time > ~/bench_begin
+echo "$current_time" > ~/bench_begin
 export RUST_BACKTRACE=1
 echo "DEGREE=$k ~/.cargo/bin/cargo test --profile bench bench_${run_suffix} -p circuit-benchmarks --features benches  -- --nocapture > \"$target_dir/results/$logfile\" 2>&1"
 DEGREE=$k ~/.cargo/bin/cargo test --profile bench bench_${run_suffix} -p circuit-benchmarks --features benches  -- --nocapture > "$target_dir/../results/$logfile" 2>&1
-
-
-exit 0

--- a/.github/weeklyBenchScripts/07_execBench.sh
+++ b/.github/weeklyBenchScripts/07_execBench.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -e
+#set -x
+GITHUB_RUN_ID=$3
+export GOROOT="/usr/local/go"
+export GOPATH="$HOME/go"
+export PATH="$GOROOT/bin:$GOPATH/bin:$PATH"
+
+# Get the latest temp directory in the home directory
+current_dir="$HOME"/CI_Prover_Benches/"$GITHUB_RUN_ID"
+
+target_dir="$current_dir/zkevm-circuits"
+k=$1
+circuit=$(echo $2 | awk '{ print $1 }' | tr '[:upper:]' '[:lower:]')
+printf -v _date '%(%Y-%m-%d_%H:%M:%S)T' -1
+
+case $circuit in
+    "all")
+        echo "To be implemented"
+        exit 1
+        ;;
+    "evm")
+        run_suffix="evm_circuit_prover"
+        ;;
+    "keccak")
+        run_suffix="keccak_round"
+        ;;
+    "state")
+        run_suffix="state_circuit_prover"
+        ;;
+    "tx")
+        run_suffix="tx_circuit_prover"
+        ;;
+    "super")
+        run_suffix="super_circuit_prover"
+        ;;
+    "bytecode")
+        run_suffix="bytecode_circuit_prover"
+        ;;
+    "pi")
+        run_suffix="pi_circuit_prover"
+        ;;
+    "exp")
+        run_suffix="exp_circuit_prover"
+        ;;
+    "copy")
+        run_suffix="copy_circuit_prover"
+        ;;
+    *)
+        echo "No proper value"
+        exit 1
+        ;;
+esac
+
+cd $target_dir;
+
+mkdir ../results
+logfile=$_date--${circuit}_bench-$k.proverlog
+
+current_time=$(date +'%H:%M:%S')
+echo "Current time: $current_time"
+echo $current_time > ~/bench_begin
+export RUST_BACKTRACE=1
+echo "DEGREE=$k ~/.cargo/bin/cargo test --profile bench bench_${run_suffix} -p circuit-benchmarks --features benches  -- --nocapture > \"$target_dir/results/$logfile\" 2>&1"
+DEGREE=$k ~/.cargo/bin/cargo test --profile bench bench_${run_suffix} -p circuit-benchmarks --features benches  -- --nocapture > "$target_dir/../results/$logfile" 2>&1
+
+
+exit 0

--- a/.github/weeklyBenchScripts/08_processResults.sh
+++ b/.github/weeklyBenchScripts/08_processResults.sh
@@ -1,37 +1,37 @@
 #!/bin/bash
-set -e
-#set -x
+set -eo pipefail
 
 label=$1
 degree=$2
 
 # Get the latest temp directory in the Triggerers directory
 trigger_results_dir="../../../results/$label"
-mkdir -p $trigger_results_dir || true
+mkdir -p "$trigger_results_dir" || true
 
 # Get the latest temp directory in the Provers home directory
-prover_latest_dir=$(ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" <<EOF
+prover_latest_dir=$(ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@"$PROVER_IP" "bash -s" <<EOF
 ls -td -- "\$HOME"/CI_Prover_Benches/* | head -1
 EOF
 )
 
 prover_target_dir="$prover_latest_dir/zkevm-circuits"
 prover_results_dir="$prover_latest_dir/results"
-echo $prover_target_dir
+echo "$prover_target_dir"
 
 # Collect results from Prover
 echo "Collecting results from $PROVER_IP:$prover_results_dir to TRIGGER_HOST:$trigger_results_dir"
-scp -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP:$prover_results_dir/*proverlog $trigger_results_dir/
+scp -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@"$PROVER_IP":"$prover_results_dir"/*proverlog "$trigger_results_dir"/
 
 # Enable bash Environment Variables for Prover
-ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" <<EOF
+ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@"$PROVER_IP" "bash -s" <<EOF
 echo "PermitUserEnvironment yes" | sudo tee -a /etc/ssh/sshd_config
 sudo service sshd restart
 EOF
 sleep 10
 
 # Collect cpu and memory metrics
-scp -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ./sadf.sh ubuntu@$PROVER_IP:~/
+scp -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ./sadf.sh ubuntu@"$PROVER_IP":~/
+# shellcheck disable=SC2086
 ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" <<EOF
 BENCH_BEGIN=\$(cat /home/ubuntu/bench_begin)
 echo "Bench began at \$BENCH_BEGIN"
@@ -39,17 +39,17 @@ mv /home/ubuntu/sadf.sh $prover_results_dir/
 cd $prover_results_dir
 ./sadf.sh \$BENCH_BEGIN
 EOF
-scp -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP:$prover_results_dir/*.stats $trigger_results_dir/
+scp -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@"$PROVER_IP":"$prover_results_dir"/*.stats "$trigger_results_dir"/
 
 # Prepare for and run data processing and db persistence
 
-l=$(echo $label | tr -d '"')
-circuit=$(echo $l |  awk '{print $1}')
+l=$(echo "$label" | tr -d '"')
+circuit=$(echo "$l" |  awk '{print $1}')
 time=$(date +%Y-%m-%d_%H-%M-%S)
 test_id=$time-$circuit-$degree-Benchmark
 
-cd $trigger_results_dir
-tar -czvf ./$test_id.tar.gz ./*proverlog ./*.stats
+cd "$trigger_results_dir"
+tar -czvf ./"$test_id".tar.gz ./*proverlog ./*.stats
 
 cp ../../zkevm-circuits/.github/weeklyBenchScripts/reporting*.py .
 sudo cp *proverlog /var/www/www_logs/
@@ -58,8 +58,7 @@ sed -i '1i BENCH-PROVER;-1;UTC;LINUX-RESTART	(64 CPU)' mem.stats
 sed -i '1i BENCH-PROVER;-1;UTC;LINUX-RESTART	(64 CPU)' cpu.stats
 python3 reporting_main.py  "$proverlog" "1" "$circuit" "$degree" "$test_id"
 
-ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" <<EOF
+ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@"$PROVER_IP" "bash -s" <<EOF
 sudo rm -rf $prover_results_dir
 EOF
 
-exit 0

--- a/.github/weeklyBenchScripts/08_processResults.sh
+++ b/.github/weeklyBenchScripts/08_processResults.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -e
+#set -x
+
+label=$1
+degree=$2
+
+# Get the latest temp directory in the Triggerers directory
+trigger_results_dir="../../../results/$label"
+mkdir -p $trigger_results_dir || true
+
+# Get the latest temp directory in the Provers home directory
+prover_latest_dir=$(ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" <<EOF
+ls -td -- "\$HOME"/CI_Prover_Benches/* | head -1
+EOF
+)
+
+prover_target_dir="$prover_latest_dir/zkevm-circuits"
+prover_results_dir="$prover_latest_dir/results"
+echo $prover_target_dir
+
+# Collect results from Prover
+echo "Collecting results from $PROVER_IP:$prover_results_dir to TRIGGER_HOST:$trigger_results_dir"
+scp -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP:$prover_results_dir/*proverlog $trigger_results_dir/
+
+# Enable bash Environment Variables for Prover
+ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" <<EOF
+echo "PermitUserEnvironment yes" | sudo tee -a /etc/ssh/sshd_config
+sudo service sshd restart
+EOF
+sleep 10
+
+# Collect cpu and memory metrics
+scp -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ./sadf.sh ubuntu@$PROVER_IP:~/
+ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" <<EOF
+BENCH_BEGIN=\$(cat /home/ubuntu/bench_begin)
+echo "Bench began at \$BENCH_BEGIN"
+mv /home/ubuntu/sadf.sh $prover_results_dir/
+cd $prover_results_dir
+./sadf.sh \$BENCH_BEGIN
+EOF
+scp -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP:$prover_results_dir/*.stats $trigger_results_dir/
+
+# Prepare for and run data processing and db persistence
+
+l=$(echo $label | tr -d '"')
+circuit=$(echo $l |  awk '{print $1}')
+time=$(date +%Y-%m-%d_%H-%M-%S)
+test_id=$time-$circuit-$degree-Benchmark
+
+cd $trigger_results_dir
+tar -czvf ./$test_id.tar.gz ./*proverlog ./*.stats
+
+cp ../../zkevm-circuits/.github/weeklyBenchScripts/reporting*.py .
+sudo cp *proverlog /var/www/www_logs/
+proverlog="http://43.130.90.57/www_logs/"$(ls -t /var/www/www_logs | head -1)
+sed -i '1i BENCH-PROVER;-1;UTC;LINUX-RESTART	(64 CPU)' mem.stats
+sed -i '1i BENCH-PROVER;-1;UTC;LINUX-RESTART	(64 CPU)' cpu.stats
+python3 reporting_main.py  "$proverlog" "1" "$circuit" "$degree" "$test_id"
+
+ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" <<EOF
+sudo rm -rf $prover_results_dir
+EOF
+
+exit 0

--- a/.github/weeklyBenchScripts/bench-results-cleanup.sh
+++ b/.github/weeklyBenchScripts/bench-results-cleanup.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
+set -eo pipefail
+
 GITHUB_RUN_ID=$1
 echo "Performing cleanup... $GITHUB_RUN_ID"
 sleep 60
-PROVER_INSTANCE=$(cat $HOME/CI_Github_Trigger/$GITHUB_RUN_ID/prover_instance)
+PROVER_INSTANCE=$(cat "$HOME"/CI_Github_Trigger/"$GITHUB_RUN_ID"/prover_instance)
 echo "Prover instance at cleanup: $PROVER_INSTANCE"
 tccli cvm TerminateInstances --InstanceIds "[\"$PROVER_INSTANCE\"]" --ReleasePrepaidDataDisk True
 echo "Exiting bench-results-local-cleanup"
 rm -rf "$HOME/CI_Github_Trigger/$GITHUB_RUN_ID"
-exit 0
+

--- a/.github/weeklyBenchScripts/bench-results-cleanup.sh
+++ b/.github/weeklyBenchScripts/bench-results-cleanup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+GITHUB_RUN_ID=$1
+echo "Performing cleanup... $GITHUB_RUN_ID"
+sleep 60
+PROVER_INSTANCE=$(cat $HOME/CI_Github_Trigger/$GITHUB_RUN_ID/prover_instance)
+echo "Prover instance at cleanup: $PROVER_INSTANCE"
+tccli cvm TerminateInstances --InstanceIds "[\"$PROVER_INSTANCE\"]" --ReleasePrepaidDataDisk True
+echo "Exiting bench-results-local-cleanup"
+rm -rf "$HOME/CI_Github_Trigger/$GITHUB_RUN_ID"
+exit 0

--- a/.github/weeklyBenchScripts/bench-results-local-trigger.sh
+++ b/.github/weeklyBenchScripts/bench-results-local-trigger.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -eo pipefail
+
 cd "$(dirname "$0")" || exit 1
 
 GITHUB_RUN_ID=$1
@@ -11,23 +13,23 @@ echo "Prover IP: $PROVER_IP"
 
 rm ~/.ssh/known_hosts*
 
-ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- <00_installGo.sh
-ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- <00_installRust.sh
-ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- <01_installDeps.sh
-ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- <02_setup.sh
+ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@"$PROVER_IP" "bash -s" -- <00_installGo.sh
+ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@"$PROVER_IP" "bash -s" -- <00_installRust.sh
+ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@"$PROVER_IP" "bash -s" -- <01_installDeps.sh
+ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@"$PROVER_IP" "bash -s" -- <02_setup.sh
 
 RESULT=""
 run_single_benchmark() {
   local DEGREE=$1
   local CIRCUIT=$2
 
-  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- "$GITHUB_RUN_ID" <03_prepareProver.sh
-  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- "$GITHUB_RUN_ID" <04_clone.sh
-  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- "$GITHUB_RUN_ID" <05_build.sh
-  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- <06_rsSysstat.sh &
+  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@"$PROVER_IP" "bash -s" -- "$GITHUB_RUN_ID" <03_prepareProver.sh
+  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@"$PROVER_IP" "bash -s" -- "$GITHUB_RUN_ID" <04_clone.sh
+  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@"$PROVER_IP" "bash -s" -- "$GITHUB_RUN_ID" <05_build.sh
+  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@"$PROVER_IP" "bash -s" -- <06_rsSysstat.sh &
   sleep 5
 
-  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- "$DEGREE" "$CIRCUIT" "$GITHUB_RUN_ID" <07_execBench.sh
+  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@"$PROVER_IP" "bash -s" -- "$DEGREE" "$CIRCUIT" "$GITHUB_RUN_ID" <07_execBench.sh
   declare -g RESULT=$?
   chmod u+x 08_processResults.sh
   ./08_processResults.sh "$CIRCUIT" "$DEGREE"

--- a/.github/weeklyBenchScripts/bench-results-local-trigger.sh
+++ b/.github/weeklyBenchScripts/bench-results-local-trigger.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+cd "$(dirname "$0")" || exit 1
+
+GITHUB_RUN_ID=$1
+
+PROVER_INSTANCE=$(cat "$HOME/CI_Github_Trigger/$GITHUB_RUN_ID/prover_instance")
+echo "Prover instance at trigger: $PROVER_INSTANCE"
+
+export PROVER_IP=$(tccli cvm DescribeInstances --InstanceIds "[\"$PROVER_INSTANCE\"]" | grep -A 1 PublicIpAddress | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')
+echo "Prover IP: $PROVER_IP"
+
+rm ~/.ssh/known_hosts*
+
+ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- <00_installGo.sh
+ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- <00_installRust.sh
+ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- <01_installDeps.sh
+ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- <02_setup.sh
+
+RESULT=""
+run_single_benchmark() {
+  local DEGREE=$1
+  local CIRCUIT=$2
+
+  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- "$GITHUB_RUN_ID" <03_prepareProver.sh
+  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- "$GITHUB_RUN_ID" <04_clone.sh
+  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- "$GITHUB_RUN_ID" <05_build.sh
+  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- <06_rsSysstat.sh &
+  sleep 5
+
+  ssh -i ~/.ssh/bench.pem -o StrictHostKeyChecking=no ubuntu@$PROVER_IP "bash -s" -- "$DEGREE" "$CIRCUIT" "$GITHUB_RUN_ID" <07_execBench.sh
+  declare -g RESULT=$?
+  chmod u+x 08_processResults.sh
+  ./08_processResults.sh "$CIRCUIT" "$DEGREE"
+}
+
+words="exp evm tx bytecode state pi copy super keccak"
+
+for word in $words; do
+  case "$word" in
+  evm)
+    # Run script for evm
+    echo "Running script for evm..."
+    run_single_benchmark 19 evm
+    ;;
+  keccak)
+    # Run script for keccak
+    echo "Running script for keccak..."
+    run_single_benchmark 19 keccak
+    ;;
+  state)
+    # Run script for state
+    echo "Running script for state..."
+    run_single_benchmark 19 state
+    ;;
+  tx)
+    # Run script for tx
+    echo "Running script for tx..."
+    run_single_benchmark 19 tx
+    ;;
+  super)
+    # Run script for super
+    echo "Running script for super..."
+    run_single_benchmark 9 super
+    ;;
+  bytecode)
+    # Run script for bytecode
+    echo "Running script for bytecode..."
+    run_single_benchmark 19 bytecode
+    ;;
+  pi)
+    # Run script for pi
+    echo "Running script for pi..."
+    run_single_benchmark 19 pi
+    ;;
+  exp)
+    # Run script for exp
+    echo "Running script for exp..."
+    run_single_benchmark 19 exp
+    ;;
+  copy)
+    # Run script for copy
+    echo "Running script for copy..."
+    run_single_benchmark 19 copy
+    ;;
+  *)
+    echo "Unknown word: $word"
+    ;;
+  esac
+done
+
+kill_ssh() {
+  sleep 30
+  # Get the list of process IDs with the given IP address
+  pids=$(ps aux | grep "$PROVER_IP" | grep -v "grep" | awk '{print $2}')
+
+  # Loop through the process IDs and kill them
+  for pid in $pids; do
+    echo "Killing process with PID: $pid"
+    kill "$pid"
+  done
+}
+
+kill_ssh &
+
+echo "Exiting bench-results-local-trigger with RESULT $RESULT"
+exit $RESULT

--- a/.github/weeklyBenchScripts/bench-results-local-trigger.sh
+++ b/.github/weeklyBenchScripts/bench-results-local-trigger.sh
@@ -60,7 +60,7 @@ for word in $words; do
   super)
     # Run script for super
     echo "Running script for super..."
-    run_single_benchmark 9 super
+    run_single_benchmark 19 super
     ;;
   bytecode)
     # Run script for bytecode

--- a/.github/weeklyBenchScripts/bench-results-setup.sh
+++ b/.github/weeklyBenchScripts/bench-results-setup.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -eo pipefail
+
 GITHUB_RUN_ID=$1
 
 make_temp_dir() {
@@ -21,8 +23,7 @@ make_temp_dir
 PROVER_INSTANCE=$(tccli cvm RunInstances --InstanceChargeType POSTPAID_BY_HOUR --InstanceChargePrepaid '{"Period":1,"RenewFlag":"DISABLE_NOTIFY_AND_MANUAL_RENEW"}' --Placement '{"Zone":"na-toronto-1"}' --InstanceType S3.16XLARGE256 --ImageId img-487zeit5 --SystemDisk '{"DiskType":"CLOUD_BSSD", "DiskSize":80}' --InternetAccessible '{"InternetChargeType":"TRAFFIC_POSTPAID_BY_HOUR","InternetMaxBandwidthOut":10,"PublicIpAssigned":true}' --InstanceCount 1 --InstanceName BENCH-PROVER --LoginSettings '{"KeyIds":[ "skey-au79yarf" ]}' --SecurityGroupIds '["sg-c3jtjz5g"]' --HostName BENCH-PROVER | egrep -o ins-[0-9a-zA-Z]*)
 #PROVER_INSTANCE=$(tccli cvm RunInstances --InstanceChargeType POSTPAID_BY_HOUR --InstanceChargePrepaid '{"Period":1,"RenewFlag":"DISABLE_NOTIFY_AND_MANUAL_RENEW"}' --Placement '{"Zone":"eu-frankfurt"}' --InstanceType S5.16XLARGE256 --ImageId img-487zeit5 --SystemDisk '{"DiskType":"CLOUD_BSSD", "DiskSize":80}' --InternetAccessible '{"InternetChargeType":"TRAFFIC_POSTPAID_BY_HOUR","InternetMaxBandwidthOut":10,"PublicIpAssigned":true}' --InstanceCount 1 --InstanceName BENCH-PROVER --LoginSettings '{"KeyIds":[ "skey-au79yarf" ]}' --SecurityGroupIds '["sg-ajrlphkl"]' --HostName BENCH-PROVER | egrep -o ins-[0-9a-zA-Z]*)
 #PROVER_INSTANCE=$(tccli cvm RunInstances --InstanceChargeType POSTPAID_BY_HOUR --InstanceChargePrepaid '{"Period":1,"RenewFlag":"DISABLE_NOTIFY_AND_MANUAL_RENEW"}' --Placement '{"Zone":"na-ashburn-2"}' --InstanceType S3.MEDIUM2 --ImageId img-487zeit5 --SystemDisk '{"DiskType":"CLOUD_BSSD", "DiskSize":50}' --InternetAccessible '{"InternetChargeType":"TRAFFIC_POSTPAID_BY_HOUR","InternetMaxBandwidthOut":10,"PublicIpAssigned":true}' --InstanceCount 1 --InstanceName BENCH-PROVER --LoginSettings '{"KeyIds":[ "skey-au79yarf" ]}' --SecurityGroupIds '["sg-ajrlphkl"]' --HostName BENCH-PROVER | egrep -o ins-[0-9a-zA-Z]*)
-echo "$PROVER_INSTANCE" > $HOME/CI_Github_Trigger/$GITHUB_RUN_ID/prover_instance
+echo "$PROVER_INSTANCE" > "$HOME"/CI_Github_Trigger/"$GITHUB_RUN_ID"/prover_instance
 echo "Prover instance at trigger: "
-cat $HOME/CI_Github_Trigger/$GITHUB_RUN_ID/prover_instance
+cat "$HOME"/CI_Github_Trigger/"$GITHUB_RUN_ID"/prover_instance
 sleep 60
-exit 0

--- a/.github/weeklyBenchScripts/bench-results-setup.sh
+++ b/.github/weeklyBenchScripts/bench-results-setup.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+GITHUB_RUN_ID=$1
+
+make_temp_dir() {
+  # Set up the directory name with the timestamp
+  directory_name="CI_Github_Trigger/$GITHUB_RUN_ID"
+
+  # Set up the full path for the directory in the home directory
+  directory_path="$HOME/$directory_name"
+
+  # Create the directory
+  mkdir -p "$directory_path"
+
+  cd "$directory_path" || exit 1
+
+  echo "Directory '$directory_name' with GITHUB_RUN_ID '$GITHUB_RUN_ID' has been created in the home directory."
+}
+
+make_temp_dir
+
+PROVER_INSTANCE=$(tccli cvm RunInstances --InstanceChargeType POSTPAID_BY_HOUR --InstanceChargePrepaid '{"Period":1,"RenewFlag":"DISABLE_NOTIFY_AND_MANUAL_RENEW"}' --Placement '{"Zone":"na-toronto-1"}' --InstanceType S3.16XLARGE256 --ImageId img-487zeit5 --SystemDisk '{"DiskType":"CLOUD_BSSD", "DiskSize":80}' --InternetAccessible '{"InternetChargeType":"TRAFFIC_POSTPAID_BY_HOUR","InternetMaxBandwidthOut":10,"PublicIpAssigned":true}' --InstanceCount 1 --InstanceName BENCH-PROVER --LoginSettings '{"KeyIds":[ "skey-au79yarf" ]}' --SecurityGroupIds '["sg-c3jtjz5g"]' --HostName BENCH-PROVER | egrep -o ins-[0-9a-zA-Z]*)
+#PROVER_INSTANCE=$(tccli cvm RunInstances --InstanceChargeType POSTPAID_BY_HOUR --InstanceChargePrepaid '{"Period":1,"RenewFlag":"DISABLE_NOTIFY_AND_MANUAL_RENEW"}' --Placement '{"Zone":"eu-frankfurt"}' --InstanceType S5.16XLARGE256 --ImageId img-487zeit5 --SystemDisk '{"DiskType":"CLOUD_BSSD", "DiskSize":80}' --InternetAccessible '{"InternetChargeType":"TRAFFIC_POSTPAID_BY_HOUR","InternetMaxBandwidthOut":10,"PublicIpAssigned":true}' --InstanceCount 1 --InstanceName BENCH-PROVER --LoginSettings '{"KeyIds":[ "skey-au79yarf" ]}' --SecurityGroupIds '["sg-ajrlphkl"]' --HostName BENCH-PROVER | egrep -o ins-[0-9a-zA-Z]*)
+#PROVER_INSTANCE=$(tccli cvm RunInstances --InstanceChargeType POSTPAID_BY_HOUR --InstanceChargePrepaid '{"Period":1,"RenewFlag":"DISABLE_NOTIFY_AND_MANUAL_RENEW"}' --Placement '{"Zone":"na-ashburn-2"}' --InstanceType S3.MEDIUM2 --ImageId img-487zeit5 --SystemDisk '{"DiskType":"CLOUD_BSSD", "DiskSize":50}' --InternetAccessible '{"InternetChargeType":"TRAFFIC_POSTPAID_BY_HOUR","InternetMaxBandwidthOut":10,"PublicIpAssigned":true}' --InstanceCount 1 --InstanceName BENCH-PROVER --LoginSettings '{"KeyIds":[ "skey-au79yarf" ]}' --SecurityGroupIds '["sg-ajrlphkl"]' --HostName BENCH-PROVER | egrep -o ins-[0-9a-zA-Z]*)
+echo "$PROVER_INSTANCE" > $HOME/CI_Github_Trigger/$GITHUB_RUN_ID/prover_instance
+echo "Prover instance at trigger: "
+cat $HOME/CI_Github_Trigger/$GITHUB_RUN_ID/prover_instance
+sleep 60
+exit 0

--- a/.github/weeklyBenchScripts/bench-results-trigger.sh
+++ b/.github/weeklyBenchScripts/bench-results-trigger.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+GITHUB_RUN_ID=$1
+
+ensure_git_installed() {
+  if ! command -v git &>/dev/null; then
+    echo "Git is not installed. Installing..."
+    sudo apt update
+    sudo apt install -y git
+  else
+    echo "Git is already installed."
+  fi
+}
+
+clone_zkevm-circuits() {
+  git clone -q https://github.com/taikoxyz/zkevm-circuits.git
+  cd zkevm-circuits || exit 1
+  echo "Cloned zkevm-circuits"
+}
+
+directory_name="$HOME/CI_Github_Trigger/$GITHUB_RUN_ID"
+cd $directory_name || exit 1
+
+ensure_git_installed
+clone_zkevm-circuits
+
+cd .github/weeklyBenchScripts || exit 1
+chmod u+x bench-results-local-trigger.sh
+./bench-results-local-trigger.sh $GITHUB_RUN_ID
+RESULT=$?
+echo "Exiting bench-results-trigger with RESULT $RESULT"
+exit $RESULT

--- a/.github/weeklyBenchScripts/bench-results-trigger.sh
+++ b/.github/weeklyBenchScripts/bench-results-trigger.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -eo pipefail
+
 GITHUB_RUN_ID=$1
 
 ensure_git_installed() {
@@ -18,14 +20,14 @@ clone_zkevm-circuits() {
 }
 
 directory_name="$HOME/CI_Github_Trigger/$GITHUB_RUN_ID"
-cd $directory_name || exit 1
+cd "$directory_name" || exit 1
 
 ensure_git_installed
 clone_zkevm-circuits
 
 cd .github/weeklyBenchScripts || exit 1
 chmod u+x bench-results-local-trigger.sh
-./bench-results-local-trigger.sh $GITHUB_RUN_ID
+./bench-results-local-trigger.sh "$GITHUB_RUN_ID"
 RESULT=$?
 echo "Exiting bench-results-trigger with RESULT $RESULT"
 exit $RESULT

--- a/.github/weeklyBenchScripts/github-action-cleanup.sh
+++ b/.github/weeklyBenchScripts/github-action-cleanup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+set -eo pipefail
 
 echo "Triggering cleanup"
-sshpass -p $BENCH_RESULTS_PASS ssh -o StrictHostKeyChecking=no ubuntu@43.130.90.57  "bash -s" -- "$GITHUB_RUN_ID" <bench-results-cleanup.sh
+sshpass -p "$BENCH_RESULTS_PASS" ssh -o StrictHostKeyChecking=no ubuntu@43.130.90.57  "bash -s" -- "$GITHUB_RUN_ID" <bench-results-cleanup.sh
 
 echo "Exiting github-action-cleanup"
-exit 0

--- a/.github/weeklyBenchScripts/github-action-cleanup.sh
+++ b/.github/weeklyBenchScripts/github-action-cleanup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "Triggering cleanup"
+sshpass -p $BENCH_RESULTS_PASS ssh -o StrictHostKeyChecking=no ubuntu@43.130.90.57  "bash -s" -- "$GITHUB_RUN_ID" <bench-results-cleanup.sh
+
+echo "Exiting github-action-cleanup"
+exit 0

--- a/.github/weeklyBenchScripts/github-action-setup.sh
+++ b/.github/weeklyBenchScripts/github-action-setup.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+ensure_ssh_and_sshpass_installed() {
+  # Check if 'ssh' is installed
+  if ! command -v ssh &>/dev/null; then
+    echo "ssh is not installed. Installing..."
+    sudo apt update
+    sudo apt install -y openssh-client
+  else
+    echo "ssh is already installed."
+  fi
+
+  # Check if 'sshpass' is installed
+  if ! command -v sshpass &>/dev/null; then
+    echo "sshpass is not installed. Installing..."
+    sudo apt update
+    sudo apt install -y sshpass
+  else
+    echo "sshpass is already installed."
+  fi
+}
+
+ensure_ssh_and_sshpass_installed
+
+echo "Triggering setup"
+sshpass -p $BENCH_RESULTS_PASS ssh -o StrictHostKeyChecking=no ubuntu@43.130.90.57  "bash -s" -- "$GITHUB_RUN_ID" <bench-results-setup.sh
+
+echo "Exiting github-action-setup"
+exit 0

--- a/.github/weeklyBenchScripts/github-action-setup.sh
+++ b/.github/weeklyBenchScripts/github-action-setup.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -eo pipefail
+
 ensure_ssh_and_sshpass_installed() {
   # Check if 'ssh' is installed
   if ! command -v ssh &>/dev/null; then
@@ -22,7 +24,6 @@ ensure_ssh_and_sshpass_installed() {
 ensure_ssh_and_sshpass_installed
 
 echo "Triggering setup"
-sshpass -p $BENCH_RESULTS_PASS ssh -o StrictHostKeyChecking=no ubuntu@43.130.90.57  "bash -s" -- "$GITHUB_RUN_ID" <bench-results-setup.sh
+sshpass -p "$BENCH_RESULTS_PASS" ssh -o StrictHostKeyChecking=no ubuntu@43.130.90.57  "bash -s" -- "$GITHUB_RUN_ID" <bench-results-setup.sh
 
 echo "Exiting github-action-setup"
-exit 0

--- a/.github/weeklyBenchScripts/github-action-trigger.sh
+++ b/.github/weeklyBenchScripts/github-action-trigger.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo "Triggering behchmark trigger"
+sshpass -p $BENCH_RESULTS_PASS ssh -o StrictHostKeyChecking=no ubuntu@43.130.90.57 "bash -s" -- "$GITHUB_RUN_ID" << EOF
+$(<bench-results-trigger.sh)
+EOF
+RESULT=$?
+echo "exiting github-acton-trigger with RESULT $RESULT"
+exit $RESULT
+
+

--- a/.github/weeklyBenchScripts/github-action-trigger.sh
+++ b/.github/weeklyBenchScripts/github-action-trigger.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
+set -eo pipefail
 
-echo "Triggering behchmark trigger"
-sshpass -p $BENCH_RESULTS_PASS ssh -o StrictHostKeyChecking=no ubuntu@43.130.90.57 "bash -s" -- "$GITHUB_RUN_ID" << EOF
+echo "Triggering benchmark trigger"
+sshpass -p "$BENCH_RESULTS_PASS" ssh -o StrictHostKeyChecking=no ubuntu@43.130.90.57 "bash -s" -- "$GITHUB_RUN_ID" << EOF
 $(<bench-results-trigger.sh)
 EOF
 RESULT=$?

--- a/.github/weeklyBenchScripts/reporting_main.py
+++ b/.github/weeklyBenchScripts/reporting_main.py
@@ -1,0 +1,36 @@
+import argparse, json
+from pprint import pprint
+import reporting_modules as rmod
+
+env = json.load(open('/etc/taiko/env.json'))
+cstats = './cpu.stats'
+mstats = './mem.stats'
+
+def main():
+    parser = argparse.ArgumentParser(
+                    prog = 'BenchmarkResults',
+                    usage = 'python3 reporting_main.py logfile 13 EVM 19',
+                    description = 'Writes circuit benchmark results to postgresql, uploads logfiles to s3 bucket',
+                    )
+    parser.add_argument('logfile')
+    parser.add_argument('pr')
+    parser.add_argument('circuit')
+    parser.add_argument('degree')
+    parser.add_argument('test_id')
+    args = parser.parse_args()
+    logfile, pr, circuit, degree, test_id = (args.logfile, args.pr, args.circuit, args.degree, args.test_id)
+    test_result = rmod.log_processor(pr,circuit, degree)
+    cpustats, memstats, sysstat = rmod.calc_stats(cstats,mstats)
+    data = rmod.prepare_result_dataframe(logfile, test_result, sysstat, env, test_id)
+    table = 'testresults_circuitbenchmark'
+    engine = rmod.pgsql_engine(env['db'])
+    data.to_sql(table,engine,if_exists='append')
+    ms = rmod.write_mem_time(engine,memstats, test_id)
+    cs = rmod.write_cpuall_time(engine,cpustats, test_id)
+
+    # url = f'{env["grafana_dashboard_prefix"]}{test_id}'.replace(" ", "")
+    # print(f'Test Result: {url}')
+
+if __name__ == '__main__':
+    main()
+

--- a/.github/weeklyBenchScripts/reporting_modules.py
+++ b/.github/weeklyBenchScripts/reporting_modules.py
@@ -1,0 +1,195 @@
+import pandas as pd, json, datetime, itertools
+from sqlalchemy import create_engine, text
+import warnings, time, os
+
+
+warnings.simplefilter(action='ignore', category=FutureWarning)
+warnings.simplefilter(action='ignore', category=UserWarning)
+pd.options.mode.chained_assignment = None
+
+def pgsql_engine(pgsqldb):
+    '''
+    creates a psql engine instance
+    '''
+    user     = pgsqldb['user']
+    password = pgsqldb['password']
+    host     = pgsqldb['host']
+    database = pgsqldb['database']
+    engine   = create_engine(f'postgresql://{user}:{password}@{host}:5432/{database}')
+
+    return engine
+
+def prepare_result_dataframe(logfile, test_result, sysstat,env, test_id):
+    '''
+    prepares postgres data (in the form of dataframe) for table circuit_benchmarks
+    '''
+    try:
+        r = {
+            # 'pull_request'          : test_result['pull_request'],
+            'test_id'               : test_id,
+            'circuit'               : test_result['circuit'],
+            'degree'                : test_result['degree'],
+            'test_result'           : test_result['result'],
+            # 'test_date'             : datetime.datetime.now().date(),
+            'setup_gen'             : test_result['setup_gen'],
+            'proof_gen'             : test_result['proof_gen'],
+            'proof_ver'             : test_result['proof_ver'],
+            'max_ram'               : sysstat['max_ram'],
+            'cpu_all_Average'       : sysstat['cpu_all_Average'],
+            'cpu_all_Max'           : sysstat['cpu_all_Max'],
+            'cpu_count'             : sysstat['cpu_count'],
+            'logfile'               : logfile,
+            # 'sysstats_url'          : f'{env["grafana_dashboard_prefix"]}{test_id}',
+            # 'logsurl'               : f'{env["s3endpoint"]}{test_id}.tar.gz'
+        }
+
+    except Exception as e:
+        print(e)
+
+    test_id = r['test_id']
+    r = pd.DataFrame([r])
+    r = r.set_index('test_id')
+
+    return r
+
+def write_mem_time(engine, mem_statistics, test_id, dummy=False):
+    '''
+    adds mem stats df as time series data to table mem_stats
+    '''
+    table = 'testresults_cbmemtime'
+    mem_statistics['dummy'] = mem_statistics['timestamp'].apply(lambda x: f'{dummy}')
+    mem_statistics['test_id'] = mem_statistics['timestamp'].apply(lambda x: f'{test_id}')
+    mem_statistics.to_sql(table,engine,if_exists='append',index=False)
+
+def write_cpuall_time(engine, cpu_statistics, test_id, dummy=False):
+    '''
+    adds cpu stats df as time series data to table mem_stats
+    '''
+    table = 'testresults_cbcpualltime'
+    cpu_statistics['dummy'] = cpu_statistics['timestamp'].apply(lambda x: f'{dummy}')
+    cpu_statistics['test_id'] = cpu_statistics['timestamp'].apply(lambda x: f'{test_id}')
+    cpu_statistics.to_sql(table,engine,if_exists='append',index=False)
+
+def calc_stats(cstats,mstats):
+    '''
+    returns 2 dataframes with cpu/mem stats to be consumed by postgresql engine
+    returns a dict with average/max cpu and max ram utilization durint the benchmark
+    '''
+    dfcpu,cpus = load_stats(cstats)
+    cpustats,cpu_all_Max,cpu_all_Average = process_cpustats(dfcpu)
+    dfmem, _ = load_stats(mstats)
+    memstats,max_ram = process_memstats(dfmem)
+    sysstat = {
+        'cpu_all_Average': cpu_all_Average,
+        'cpu_all_Max'    : cpu_all_Max,
+        'cpu_count'      : cpus,
+        'max_ram'        : f'{max_ram}Gb'
+    }
+
+    return cpustats, memstats, sysstat
+
+def log_processor(pull_request,circuit, degree):
+    '''
+    Exports test metadata and result metrics from prover logfile
+    '''
+    SETUP_PREFIX     = "[Setup generation]"
+    PROOFGEN_PREFIX  = "[Proof generation]"
+    PROOFVER_PREFIX  = "[Proof verification]"
+    logfile = [i for i in os.listdir('./') if 'proverlog' in i][0]
+    f = open(f'./{logfile}', 'r')
+    logdata = f.read()
+    logdata = logdata.split("\n")
+    running = [i for i in logdata if 'running' in i and 'test' in i][0].split()[1]
+    if running != '0':
+        r = [i.split(":")[1].split(".")[0].replace(" ","") for i in logdata if 'test result' in i][0]
+        if r == 'ok':
+            result = 'PASSED'
+            try:
+                sg = ''.join(g[0] for g in itertools.groupby([i for i in logdata if 'End' in i and SETUP_PREFIX in i ][0])).split('.', 1)[-1]
+            except:
+                sg = 'None'
+            try:
+                pg = ''.join(g[0] for g in itertools.groupby([i for i in logdata if 'End' in i and PROOFGEN_PREFIX in i ][0])).split('.', 1)[-1]
+            except:
+                pg = 'None'
+            try:
+                pv = ''.join(g[0] for g in itertools.groupby([i for i in logdata if 'End' in i and PROOFVER_PREFIX in i ][0])).split('.', 1)[-1]
+            except:
+                pv = 'None'
+            logdata = {
+                    # 'pull_request': pull_request,
+                    'circuit'     : circuit,
+                    'degree'      : degree,
+                    'result'      : result,
+                    'setup_gen'   : sg,
+                    'proof_gen'   : pg,
+                    'proof_ver'   : pv
+                }
+        else:
+            result = 'FAILED'
+            logdata = {
+                # 'pull_request': pull_request,
+                'circuit'     : circuit,
+                'degree'      : degree,
+                'result'      : result,
+                'setup_gen'   : 'None',
+                'proof_gen'   : 'None',
+                'proof_ver'   : 'None'
+            }
+
+    else:
+        result = 'None'
+        logdata = {
+            # 'pull_request': pull_request,
+            'circuit'     : circuit,
+            'degree'      : degree,
+            'result'      : result,
+            'setup_gen'   : 'NoTestExecuted',
+            'proof_gen'   : 'NoTestExecuted',
+            'proof_ver'   : 'NoTestExecuted'
+            }
+
+
+    return logdata
+
+def load_stats(file):
+    '''
+    loads raw mem/cpu sar data from csv to dataframe
+    '''
+    try:
+        with open(file,'r') as filedata:
+            filedatalist = [i for i in filedata.read().splitlines()]
+            header = [i for i in filedatalist if 'LINUX-RESTART' in i][0]
+            cpus = header.split('(')[1].split()[0]
+            cpudatalist = [i for i in filedatalist if 'LINUX-RESTART' not in i]
+            columns = cpudatalist[0].split(';')
+            cpudatalist = [i for i in cpudatalist if 'hostname' not in i]
+            df = pd.DataFrame([i.split(';') for i in cpudatalist], columns=columns)
+        return df, cpus
+    except Exception as e:
+        print(e)
+        return None
+
+def process_cpustats(statsdf):
+    '''
+    accepts cpu stats raw data from csv and returns a dataframe for further processing
+    '''
+    statsdf = statsdf[['timestamp', '%idle']]
+    statsdf['%idle']   = pd.to_numeric(statsdf['%idle'])
+    statsdf['utilizationall'] = statsdf['%idle'].apply(lambda x:round(float(100) - x, 2 ))
+    statsdf = statsdf[['timestamp','utilizationall']]
+    cpu_all_Max = statsdf['utilizationall'].max()
+    cpu_all_Average = statsdf['utilizationall'].mean()
+    return statsdf, cpu_all_Max,cpu_all_Average
+
+
+def process_memstats(df):
+    '''
+    accepts ram stats raw data  and returns a dataframe for further processing
+    '''
+    statsdf = df[['timestamp', 'kbmemused']]
+    statsdf['kbmemused']   = pd.to_numeric(statsdf['kbmemused'])
+    statsdf['utilizationgb']   = statsdf['kbmemused'].apply(lambda x: round(x/float(1000000),2))
+    statsdf = statsdf[['timestamp','utilizationgb']]
+    max_ram = statsdf['utilizationgb'].max()
+    return statsdf, max_ram

--- a/.github/weeklyBenchScripts/sadf.sh
+++ b/.github/weeklyBenchScripts/sadf.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+echo "Input to sadf $1"
+#sleep 5
+sudo rm -f /var/log/sysstat/sar*
+
+sadf -s $1 -d >> cpu.stats
+sadf -s $1 -d -- -r >> mem.stats
+

--- a/.github/weeklyBenchScripts/sadf.sh
+++ b/.github/weeklyBenchScripts/sadf.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
+set -eo pipefail
 
 echo "Input to sadf $1"
 #sleep 5
 sudo rm -f /var/log/sysstat/sar*
 
-sadf -s $1 -d >> cpu.stats
-sadf -s $1 -d -- -r >> mem.stats
+sadf -s "$1" -d >> cpu.stats
+sadf -s "$1" -d -- -r >> mem.stats
 

--- a/.github/workflows/cloud-run.yml
+++ b/.github/workflows/cloud-run.yml
@@ -1,0 +1,40 @@
+name: Tencent Run
+
+on:
+  workflow_dispatch:
+    inputs:
+      BRANCH_NAME:
+        description: 'BRANCH_NAME'
+        required: true
+env:
+  BENCH_RESULTS_PASS: ${{ secrets.BENCH_RESULTS_PASS }}
+
+jobs:
+  taiko-cloud-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+
+      - name: Setup
+        run: |
+          cd .github/weeklyBenchScripts
+          ./github-action-setup.sh
+        env:
+          GITHUB_RUN_ID: ${{ vars.GITHUB_RUN_ID }}
+
+      - name: Trigger
+        run: |
+          cd .github/cloudRun
+          ./github-action-trigger.sh
+        env:
+          GITHUB_RUN_ID: ${{ vars.GITHUB_RUN_ID }}
+          BRANCH_NAME: ${{ inputs.BRANCH_NAME || github.event.client_payload.BRANCH_NAME }}
+
+      - name: Cleanup
+        run: |
+          cd .github/weeklyBenchScripts
+          ./github-action-cleanup.sh
+        if: always()
+        env:
+          GITHUB_RUN_ID: ${{ vars.GITHUB_RUN_ID }}

--- a/.github/workflows/weekly-bench.yml
+++ b/.github/workflows/weekly-bench.yml
@@ -1,0 +1,38 @@
+name: Weekly Circuits Benchmark
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * MON"
+
+env:
+  BENCH_RESULTS_PASS: ${{ secrets.BENCH_RESULTS_PASS }}
+
+jobs:
+  taiko-weekly-circuits-benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+
+      - name: Setup
+        run: |
+          cd .github/weeklyBenchScripts
+          ./github-action-setup.sh
+        env:
+          GITHUB_RUN_ID: ${{ vars.GITHUB_RUN_ID }}
+
+      - name: Trigger
+        run: |
+          cd .github/weeklyBenchScripts
+          ./github-action-trigger.sh
+        env:
+          GITHUB_RUN_ID: ${{ vars.GITHUB_RUN_ID }}
+
+      - name: Cleanup
+        run: |
+          cd .github/weeklyBenchScripts
+          ./github-action-cleanup.sh
+        if: always()
+        env:
+          GITHUB_RUN_ID: ${{ vars.GITHUB_RUN_ID }}


### PR DESCRIPTION
### Description

This PR adds the support for:
- running weekly circuit benchmarks on Tencent Cloud, triggered by Github Actions
- running on demand arbitrary test commands on Tencent Cloud, triggered manually by using Github Actions

### Issue Link

[_link issue here_]

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Contents

- .github/workflows/weekly-bench.yml
- .github/workflows/cloud-run.yml
- .github/weeklyBenchScripts/*
- .github/cloudRun/*

### Rationale

Since both circuit benchmarks and circuit tests require a large amount of memory, it is best to have them running in the Cloud.

### How Has This Been Tested?

By running through multiple times.
