### PR TITLE
PI circuit for A5 testnet

### DIFF
--- a/circuit-benchmarks/src/lib.rs
+++ b/circuit-benchmarks/src/lib.rs
@@ -8,7 +8,7 @@ pub mod state_circuit;
 #[cfg(feature = "benches")]
 pub mod tx_circuit;
 
-// #[cfg(test)]
+#[cfg(test)]
 //#[cfg(feature = "benches")]
 pub mod super_circuit;
 
@@ -32,6 +32,6 @@ pub mod copy_circuit;
 #[cfg(feature = "benches")]
 pub mod exp_circuit;
 
-// #[cfg(test)]
+#[cfg(test)]
 //#[cfg(feature = "benches")]
 pub mod constants;

--- a/circuit-benchmarks/src/super_circuit.rs
+++ b/circuit-benchmarks/src/super_circuit.rs
@@ -129,7 +129,7 @@ fn write_bytes(name: &str, vec: &[u8]) {
         .unwrap_or_else(|_| panic!("write {}", &path));
 }
 
-pub fn gen_verifier(
+fn gen_verifier(
     params: &ProverParams,
     vk: &VerifyingKey<G1Affine>,
     config: Config,
@@ -164,7 +164,7 @@ pub fn gen_verifier(
     yul
 }
 
-pub fn evm_verify(deployment_code: Vec<u8>, instances: Vec<Vec<Fr>>, proof: Vec<u8>) {
+fn evm_verify(deployment_code: Vec<u8>, instances: Vec<Vec<Fr>>, proof: Vec<u8>) {
     let calldata = encode_calldata(&instances, &proof);
     println!(
         "deploy code size: {} bytes, instances size: [{}][{}], calldata: {}",

--- a/zkevm-circuits/src/taiko_pi_circuit.rs
+++ b/zkevm-circuits/src/taiko_pi_circuit.rs
@@ -53,7 +53,7 @@ impl<F: Field> FieldGadget<F> {
         self.field.iter().map(|f| f.expr()).collect()
     }
 
-    fn acc(&self, r: Expression<F>) -> Expression<F> {
+    fn rlc_acc(&self, r: Expression<F>) -> Expression<F> {
         //0.expr()
         self.bytes_expr().rlc_rev(&r)
     }
@@ -178,11 +178,7 @@ impl<F: Field> PublicData<F> {
     fn total_acc(&self, r: Value<F>) -> F {
         let mut rand = F::ZERO;
         r.map(|r| rand = r);
-        self.encode_raw()
-            .iter()
-            .fold(F::ZERO, |acc: F, byte| {
-                acc * rand + F::from(*byte as u64)
-            }) 
+        rlc::value(self.encode_raw().iter().rev(), rand)
     }
 
     fn assignment(&self, idx: usize) -> Vec<F> {
@@ -201,18 +197,8 @@ impl<F: Field> PublicData<F> {
     fn keccak_hi_low(&self) -> [F; 2] {
         let keccaked_pi = keccak256(self.encode_raw());
         [
-            keccaked_pi
-                .iter()
-                .take(16)
-                .fold(F::ZERO, |acc: F, byte| {
-                    acc * F::from(BYTE_POW_BASE) + F::from(*byte as u64)
-                }),
-                keccaked_pi
-                .iter()
-                .skip(16)
-                .fold(F::ZERO, |acc: F, byte| {
-                    acc * F::from(BYTE_POW_BASE) + F::from(*byte as u64)
-                })
+            rlc::value(keccaked_pi[0..16].iter().rev(), BYTE_POW_BASE.scalar()),
+            rlc::value(keccaked_pi[16..].iter().rev(), BYTE_POW_BASE.scalar()),
         ]
     }
 
@@ -293,12 +279,12 @@ impl<F: Field> SubCircuitConfig<F> for TaikoPiCircuitConfig<F> {
         let cm = CellManager::new(
             meta,
             vec![
-                (PiCellType::Byte, 7, 1, false),
+                (PiCellType::Byte, 15, 1, false),
                 (PiCellType::StoragePhase1, 1, 1, true),
-                (PiCellType::StoragePhase2, 1, 2, true),
+                (PiCellType::StoragePhase2, 1, 1, true),
             ],
             0,
-            DEFAULT_LEN,
+            15,
         );
         let mut cb: ConstraintBuilder<F, PiCellType> = ConstraintBuilder::new(4,  Some(cm.clone()), Some(evm_word.expr()));
         cb.preload_tables(meta,
@@ -334,13 +320,13 @@ impl<F: Field> SubCircuitConfig<F> for TaikoPiCircuitConfig<F> {
             "PI acc constraints", 
             |meta| {
                 circuit!([meta, cb], {
-                    for (n, b, acc) in [parent_hash.clone() , block_hash.clone()] {
-                        require!(acc.expr() => b.acc(evm_word.expr()));
+                    for (block_number, block_hash, block_hash_rlc) in [parent_hash.clone() , block_hash.clone()] {
+                        require!(block_hash_rlc.expr() => block_hash.rlc_acc(evm_word.expr()));
                         require!(
                             (
                                 BlockContextFieldTag::BlockHash.expr(), 
-                                n.expr(), 
-                                acc.expr()
+                                block_number.expr(), 
+                                block_hash_rlc.expr()
                             ) => @PiCellType::Lookup(Table::Block), (TO_FIX)
                         );
                     }
@@ -353,7 +339,7 @@ impl<F: Field> SubCircuitConfig<F> for TaikoPiCircuitConfig<F> {
                         prover.clone(), 
                     ].iter().fold(0.expr(), |acc, gadget| {
                         let mult = (0..gadget.len).fold(1.expr(), |acc, _| acc * keccak_r.expr());
-                        acc * mult + gadget.acc(keccak_r.expr())
+                        acc * mult + gadget.rlc_acc(keccak_r.expr())
                     });
                     require!(total_acc.expr() => acc_val);
                     require!(
@@ -361,7 +347,7 @@ impl<F: Field> SubCircuitConfig<F> for TaikoPiCircuitConfig<F> {
                             1.expr(), 
                             total_acc.expr(), 
                             evidence.total_len().expr(), 
-                            keccak_bytes.acc(evm_word.expr())
+                            keccak_bytes.rlc_acc(evm_word.expr())
                         )
                         => @PiCellType::Lookup(Table::Keccak), (TO_FIX)
                     );
@@ -385,8 +371,8 @@ impl<F: Field> SubCircuitConfig<F> for TaikoPiCircuitConfig<F> {
             Some(q_enable)
         );
         let annotation_configs = cm.columns().to_vec();
-        println!("#col {:?}\n#constraints {:?}\n#lookup {:?}\n#permu {:?}\nrotation {:?}", 
-            meta.num_advice_columns() + meta.num_fixed_columns(), meta.gates().len(), meta.lookups().len(), meta.permutation().get_columns().len(), cm.get_height());
+        // println!("#col {:?} + {:?}\n#constraints {:?}\n#lookup {:?}\n#permu {:?}\nrotation {:?}", 
+        //     meta.num_advice_columns(), meta.num_fixed_columns(), meta.gates().len(), meta.lookups().len(), meta.permutation().get_columns().len(), cm.get_height());
         Self {
             q_enable, 
             keccak_instance,
@@ -502,7 +488,6 @@ impl<F: Field> SubCircuit<F> for TaikoPiCircuit<F> {
         challenges: &Challenges<Value<F>>,
         layouter: &mut impl Layouter<F>,
     ) -> Result<(), Error> {
-        config.byte_table.load(layouter)?;
         config.assign(layouter, challenges, &self.evidence)
     }
 }
@@ -584,7 +569,9 @@ mod taiko_pi_circuit_test {
     use halo2_proofs::{
         dev::{MockProver, VerifyFailure},
         halo2curves::bn256::Fr,
+        plonk::{create_proof, keygen_pk, keygen_vk, verify_proof},
     };
+    use snark_verifier_sdk::halo2::gen_srs;
     use lazy_static::lazy_static;
     use pretty_assertions::assert_eq;
 
@@ -717,6 +704,34 @@ mod taiko_pi_circuit_test {
         assert_eq!(run::<Fr>(k, evidence, None), Ok(()));
     }
 
+    #[ignore = "takes too long"]
+    #[test]
+    fn test_from_integration() {
+        let mut block1 = witness::Block::<Fr>::default();
+
+        block1.eth_block.parent_hash = *LAST_HASH;
+        block1.eth_block.hash = Some(*THIS_HASH);
+        block1.protocol_instance.block_hash = *THIS_HASH;
+        block1.protocol_instance.parent_hash = *LAST_HASH;
+        block1.context.history_hashes = vec![LAST_HASH.to_word()];
+        block1.context.block_hash = Some(THIS_HASH.to_word());
+        block1.context.number = 300.into();
+        let evidence1 = PublicData::new(&block1);
+        let circuit1 = TaikoPiCircuit::new(evidence1);
+
+        let mut block2 = witness::Block::<Fr>::default();
+        block2.protocol_instance.prover = *PROVER_ADDR;
+        let evidence2 = PublicData::new(&block2);
+        let circuit2 = TaikoPiCircuit::new(evidence2);
+        
+        let k = 22;
+        let params = gen_srs(k);
+        let vk1 = keygen_vk(&params, &circuit1).expect("keygen_vk should not fail");
+        let vk2 = keygen_vk(&params, &circuit2).expect("keygen_vk should not fail");
+        let pk1 = keygen_pk(&params, vk1.clone(), &circuit1).unwrap();
+        let pk2 = keygen_pk(&params, vk2.clone(), &circuit2).unwrap();
+        println!("{:?}\n{:?}", vk1, vk2);
+    }
 
 }
 

--- a/zkevm-circuits/src/taiko_super_circuit.rs
+++ b/zkevm-circuits/src/taiko_super_circuit.rs
@@ -177,6 +177,7 @@ impl<F: Field> Circuit<F> for SuperCircuit<F> {
             vec![&self.pi_circuit.evidence.encode_raw()],
             &challenges,
         )?;
+        config.byte_table.load(&mut layouter)?;
         self.synthesize_sub(&config, &challenges, &mut layouter)
     }
 }


### PR DESCRIPTION
### Description

Prove protocol instance get from Taiko contract.
```
keccak256(abi.encode(
            evidance.metaHash,
            evidance.parentHash,
            evidance.blockHash,
            evidance.signalRoot,
            evidance.graffiti,
            evidance.prover
 ));
```
1. bytes of `keccak_output` <==> 'hi' and `lo` values in circuit's instance column
2. `parentHash` can be found in historical hashes of circuit. (BlockTable lookup)
3. `blockHash` can be found in circuit. (BlockTable lookup)
4. [RLC(abi encoded values above), len, RLC(bytes of `keccak_output`)] can be found in KeccakTable lookup.

### Issue Link
#138 converted for A5 testnet

### Type of change
- [x] Rewrite most logics in circuit-tools