### PR TITLE
workaround: make storage proof optional

### DIFF
--- a/eth-types/src/lib.rs
+++ b/eth-types/src/lib.rs
@@ -288,7 +288,7 @@ pub struct StorageProof {
     /// Storage Value
     pub value: U256,
     /// Storage proof: rlp-encoded trie nodes from root to value.
-    pub proof: Vec<Bytes>,
+    pub proof: Option<Vec<Bytes>>,
 }
 
 /// Struct used to define the result of `eth_getProof` call


### PR DESCRIPTION
Try addressing https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1675
