### PR TITLE
Use a6 tag for halo2 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,7 +663,7 @@ dependencies = [
  "ethers-core",
  "ethers-providers",
  "gadgets",
- "halo2_proofs 0.2.0",
+ "halo2_proofs 0.2.0 (git+https://github.com/taikoxyz/halo2.git?tag=taiko-alpha-6)",
  "hex",
  "itertools",
  "keccak256",
@@ -826,7 +826,7 @@ dependencies = [
  "env_logger",
  "eth-types",
  "ethers-signers",
- "halo2_proofs 0.2.0",
+ "halo2_proofs 0.2.0 (git+https://github.com/taikoxyz/halo2.git?tag=taiko-alpha-6)",
  "hex",
  "itertools",
  "keccak256",
@@ -1676,7 +1676,7 @@ version = "0.1.0"
 dependencies = [
  "ethers-core",
  "ethers-signers",
- "halo2_proofs 0.2.0",
+ "halo2_proofs 0.2.0 (git+https://github.com/taikoxyz/halo2.git?tag=taiko-alpha-6)",
  "hex",
  "itertools",
  "lazy_static",
@@ -2309,7 +2309,7 @@ version = "0.1.0"
 dependencies = [
  "digest 0.7.6",
  "eth-types",
- "halo2_proofs 0.2.0",
+ "halo2_proofs 0.2.0 (git+https://github.com/taikoxyz/halo2.git?tag=taiko-alpha-6)",
  "rand",
  "rand_xorshift",
  "sha3 0.7.3",
@@ -2458,6 +2458,24 @@ dependencies = [
 [[package]]
 name = "halo2_proofs"
 version = "0.2.0"
+source = "git+https://github.com/taikoxyz/halo2.git?tag=taiko-alpha-6#fb69aa2d6c1bc4afaab360adaca40aee69a76ac8"
+dependencies = [
+ "ark-std 0.3.0",
+ "blake2b_simd",
+ "ff 0.13.0",
+ "group 0.13.0",
+ "halo2curves",
+ "itertools",
+ "rand_chacha",
+ "rand_core",
+ "rayon",
+ "sha3 0.9.1",
+ "tracing",
+]
+
+[[package]]
+name = "halo2_proofs"
+version = "0.2.0"
 source = "git+https://github.com/taikoxyz/halo2.git?branch=taiko/unstable#fb69aa2d6c1bc4afaab360adaca40aee69a76ac8"
 dependencies = [
  "ark-std 0.3.0",
@@ -2496,7 +2514,7 @@ name = "halo2wrong"
 version = "0.1.0"
 source = "git+https://github.com/taikoxyz/halo2wrong?branch=a6-integration#07afd1119dd34693a0ad7af0e74b5b2b66d3196f"
 dependencies = [
- "halo2_proofs 0.2.0",
+ "halo2_proofs 0.2.0 (git+https://github.com/taikoxyz/halo2.git?branch=taiko/unstable)",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -2854,7 +2872,7 @@ dependencies = [
  "env_logger",
  "eth-types",
  "ethers",
- "halo2_proofs 0.2.0",
+ "halo2_proofs 0.2.0 (git+https://github.com/taikoxyz/halo2.git?tag=taiko-alpha-6)",
  "lazy_static",
  "log",
  "mock",
@@ -3203,7 +3221,7 @@ dependencies = [
  "ethers-core",
  "ethers-signers",
  "external-tracer",
- "halo2_proofs 0.2.0",
+ "halo2_proofs 0.2.0 (git+https://github.com/taikoxyz/halo2.git?tag=taiko-alpha-6)",
  "itertools",
  "lazy_static",
  "libsecp256k1",
@@ -4793,7 +4811,7 @@ version = "0.1.1"
 source = "git+https://github.com/taikoxyz/snark-verifier.git?branch=a6-integration#612f4950197af29883b6e67f9099117318579f99"
 dependencies = [
  "ecc",
- "halo2_proofs 0.2.0",
+ "halo2_proofs 0.2.0 (git+https://github.com/taikoxyz/halo2.git?branch=taiko/unstable)",
  "halo2curves",
  "hex",
  "itertools",
@@ -4817,7 +4835,7 @@ dependencies = [
  "bincode",
  "ecc",
  "ethereum-types",
- "halo2_proofs 0.2.0",
+ "halo2_proofs 0.2.0 (git+https://github.com/taikoxyz/halo2.git?branch=taiko/unstable)",
  "halo2curves",
  "hex",
  "itertools",
@@ -5088,7 +5106,7 @@ dependencies = [
  "ethers-signers",
  "external-tracer",
  "glob",
- "halo2_proofs 0.2.0",
+ "halo2_proofs 0.2.0 (git+https://github.com/taikoxyz/halo2.git?tag=taiko-alpha-6)",
  "handlebars",
  "hex",
  "keccak256",
@@ -5896,7 +5914,7 @@ dependencies = [
  "ethers-core",
  "ethers-signers",
  "gadgets",
- "halo2_proofs 0.2.0",
+ "halo2_proofs 0.2.0 (git+https://github.com/taikoxyz/halo2.git?tag=taiko-alpha-6)",
  "hex",
  "integer",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [patch.crates-io]
-halo2_proofs = { git = "https://github.com/taikoxyz/halo2.git", branch = "taiko/unstable" }
+halo2_proofs = { git = "https://github.com/taikoxyz/halo2.git", tag = "taiko-alpha-6" }
 
 # Definition of benchmarks profile to use.
 [profile.bench]

--- a/bus-mapping/Cargo.toml
+++ b/bus-mapping/Cargo.toml
@@ -23,7 +23,7 @@ alloy-dyn-abi = { version = "0.4" }
 
 ethers-core = "=2.0.0"
 ethers-providers = "=2.0.0"
-halo2_proofs = { git = "https://github.com/taikoxyz/halo2.git", branch = "taiko/unstable" }
+halo2_proofs = { git = "https://github.com/taikoxyz/halo2.git", tag = "taiko-alpha-6" }
 itertools = "0.10"
 lazy_static = "1.4"
 log = "0.4.14"

--- a/circuit-benchmarks/Cargo.toml
+++ b/circuit-benchmarks/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-halo2_proofs = { git = "https://github.com/taikoxyz/halo2.git", branch = "taiko/unstable" }
+halo2_proofs = { git = "https://github.com/taikoxyz/halo2.git", tag = "taiko-alpha-6" }
 snark-verifier = { git = "https://github.com/taikoxyz/snark-verifier.git", branch = "a6-integration", default-features = false, features = [
     "loader_halo2",
     "system_halo2",

--- a/eth-types/Cargo.toml
+++ b/eth-types/Cargo.toml
@@ -10,7 +10,7 @@ ethers-core = "=2.0.0"
 ethers-signers = "=2.0.0"
 hex = "0.4"
 lazy_static = "1.4"
-halo2_proofs = { git = "https://github.com/taikoxyz/halo2.git", branch = "taiko/unstable" }
+halo2_proofs = { git = "https://github.com/taikoxyz/halo2.git", tag = "taiko-alpha-6" }
 regex = "1.5.4"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.66"

--- a/gadgets/Cargo.toml
+++ b/gadgets/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["The appliedzkp team"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-halo2_proofs = { git = "https://github.com/taikoxyz/halo2.git", branch = "taiko/unstable" }
+halo2_proofs = { git = "https://github.com/taikoxyz/halo2.git", tag = "taiko-alpha-6" }
 sha3 = "0.7.2"
 eth-types = { path = "../eth-types" }
 digest = "0.7.6"

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -20,7 +20,7 @@ url = "2.2.2"
 pretty_assertions = "1.0.0"
 log = "0.4.14"
 env_logger = "0.9"
-halo2_proofs = { git = "https://github.com/taikoxyz/halo2.git", branch = "taiko/unstable" }
+halo2_proofs = { git = "https://github.com/taikoxyz/halo2.git", tag = "taiko-alpha-6" }
 rand_chacha = "0.3"
 paste = "1.0"
 rand_xorshift = "0.3.0"

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 halo2_proofs = { git = "https://github.com/taikoxyz/halo2.git", features = [
   "circuit-params",
-], branch = "taiko/unstable"}
+], tag = "taiko-alpha-6"}
 eth-types = { path = "../eth-types" }
 external-tracer = { path = "../external-tracer" }
 lazy_static = "1.4"

--- a/testool/Cargo.toml
+++ b/testool/Cargo.toml
@@ -33,7 +33,7 @@ yaml-rust = "0.4.5"
 zkevm-circuits = { path = "../zkevm-circuits", features = ["test"] }
 rand_chacha = "0.3"
 rand = "0.8"
-halo2_proofs = { git = "https://github.com/taikoxyz/halo2.git", branch = "taiko/unstable" }
+halo2_proofs = { git = "https://github.com/taikoxyz/halo2.git", tag = "taiko-alpha-6" }
 urlencoding = "2.1.2"
 
 

--- a/zkevm-circuits/Cargo.toml
+++ b/zkevm-circuits/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-halo2_proofs = { git = "https://github.com/taikoxyz/halo2.git", features = ["circuit-params"], branch = "taiko/unstable" }
+halo2_proofs = { git = "https://github.com/taikoxyz/halo2.git", features = ["circuit-params"], tag = "taiko-alpha-6" }
 num = "0.4"
 sha3 = "0.10"
 array-init = "2.0.0"


### PR DESCRIPTION
This fixes the halo2 dependency to `taiko-alpha-6` tag so that `taiko/unstable` can evolve independently and in particular integrate upstream changes.